### PR TITLE
Redux apollo separation

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 build
 .env
+coverage

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,13 +5,24 @@ import Home from './components/Home'
 import AppBar from './components/AppBar'
 import Login from './components/Login'
 import { useAppDispatch } from './hooks'
-import { setUserFromToken } from './reducers/userReducer'
+import { setUser } from './reducers/userReducer'
 import SignIn from './components/SignIn'
 import Notification from './components/Notification'
+import { useQuery } from '@apollo/client'
+import { USER } from './graphql/queries/userQueries'
+import { useEffect } from 'react'
 
 const App = () => {
   const dispatch = useAppDispatch()
-  dispatch(setUserFromToken())
+  const { data } = useQuery(USER)
+
+  useEffect(() => {
+      const token = window.localStorage.getItem('recipeapp-userToken')
+      if (token && data && data?.me) {
+        dispatch(setUser(data.me))
+      }
+  }, [data, dispatch])
+
 
 
   return (

--- a/frontend/src/components/SignIn.tsx
+++ b/frontend/src/components/SignIn.tsx
@@ -1,22 +1,28 @@
 import { Button, TextField, Typography } from "@mui/material"
 import { SyntheticEvent, useState } from "react"
-import { userSignIn } from "../reducers/userReducer"
 import { useAppDispatch } from "../hooks"
+import { useMutation } from "@apollo/client"
+import { SIGN_IN } from "../graphql/queries/userQueries"
+import { notify } from "../reducers/notificationReducer"
 
 
 const SignIn = () => {
   const [username, setUsername] = useState('')
   const [password, setPassword] = useState('')
   const dispatch = useAppDispatch()
+  const [signIn] = useMutation(SIGN_IN)
 
   const handleSignIn = async (event: SyntheticEvent) => {
     event.preventDefault()
-    const success = await dispatch(userSignIn({username, password}))
-    if (success) {
+    try {
+      await signIn({variables: {username, password}})
       setUsername('')
       setPassword('')
+      dispatch(notify({severity: "success", message:`Sign In Successful. You can now Login with your credentials`}))
+    } catch {
+      dispatch(notify({severity: "error", message:`Sign In failed`}))
     }
-  }
+  } 
 
   return (
     <>

--- a/frontend/src/reducers/userReducer.ts
+++ b/frontend/src/reducers/userReducer.ts
@@ -1,8 +1,6 @@
 import { createSlice, PayloadAction, ThunkAction, UnknownAction } from '@reduxjs/toolkit'
-import { SafeUser, UserFromInputs } from '../types/user'
+import { SafeUser } from '../types/user'
 import { RootState } from '../store'
-import { apolloClient } from '../graphql/apolloClient'
-import { LOGIN, SIGN_IN, USER } from '../graphql/queries/userQueries'
 import { notify } from './notificationReducer'
 
 const userSlice = createSlice({
@@ -17,60 +15,11 @@ const userSlice = createSlice({
 
 export const { setUser } = userSlice.actions
 
-export const userLogin = (user: UserFromInputs): ThunkAction<Promise<boolean>, RootState, unknown, UnknownAction> => {
-  return async dispatch => {
-    const response = await apolloClient.mutate({
-      mutation: LOGIN,
-      variables: {username: user.username, password: user.password},
-      errorPolicy: "all"
-    })
-    if (response.errors) {
-      const message = response.errors?.[0]?.message
-      dispatch(notify({severity: "error", message:`Login failed. Message: ${message}`}))
-      return false
-    } else {
-      window.localStorage.setItem('recipeapp-userToken', response.data.login.value)
-      dispatch(setUserFromToken())
-      dispatch(notify({severity: "success", message:`Login Successful!`}))
-      return true
-    }
-  }
-}
-
 export const userLogout = (): ThunkAction<void, RootState, unknown, UnknownAction> => {
   return async dispatch => {
     window.localStorage.removeItem('recipeapp-userToken')
     dispatch(setUser(null))
     dispatch(notify({severity: "success", message:`Logout Successful!`}))
-  }
-}
-
-export const userSignIn = (user: UserFromInputs): ThunkAction<Promise<boolean>, RootState, unknown, UnknownAction> => {
-  return async dispatch => {
-    const response = await apolloClient.mutate({
-      mutation: SIGN_IN,
-      variables: {username: user.username, password: user.password},
-      errorPolicy: "all"
-    })
-    if (response.errors) {
-      const message = response.errors?.[0]?.message
-      dispatch(notify({severity: "error", message:`Sign in failed. Message: ${message}`}))
-      return false
-    } else {
-      dispatch(notify({severity: "success", message:`Sign In Successful. You can now Login with your credentials`}))
-      return true
-    }
-  }
-}
-
-export const setUserFromToken = (): ThunkAction<void, RootState, unknown, UnknownAction> => {
-  return async dispatch => {
-    const userToken = window.localStorage.getItem('recipeapp-userToken')
-    if (!userToken) dispatch(setUser(null))
-    else {
-      const response = await apolloClient.query({ query: USER })
-      dispatch(setUser(response.data.me))
-    }
   }
 }
 


### PR DESCRIPTION
- Moves apollo queries to use ApolloProvider instead of apolloClient, which makes writing frontend unit tests easier by separating it from Redux Thunk actions